### PR TITLE
fix: Creating a dir instead of a bin

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,7 +47,7 @@ aurs:
       - git
     package: |-
       # bin
-      install -Dm755 "./waku" -t "$pkgdir/usr/bin/waku"
+      install -Dm755 "./waku" -t "$pkgdir/usr/bin"
 
       # license
       install -Dm644 "./LICENSE" "$pkgdir/usr/share/licenses/waku"


### PR DESCRIPTION
This fixes creating the binary at /bin/waku/waku instead of the proper /bin/waku. This is dumb. I've already pushed this fix to the AUR.