### PR TITLE
feat: Initialize git in generated project

### DIFF
--- a/cmd/commands/new.go
+++ b/cmd/commands/new.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strings"
@@ -237,6 +238,20 @@ var NewCmd = &cobra.Command{
 			exitCode = 1
 			return
 		}
+
+		if options.NewOpts.NoGit {
+			options.Infoln("skipping git initialization")
+		} else {
+			cmd.Println("initializing git...")
+			initGit := exec.Command("git", "init")
+			initGit.Dir = projectRootDir
+
+			if err := initGit.Run(); err != nil {
+				fmt.Printf("failed to initialize git: %s\n", err)
+				exitCode = 1
+				return
+			}
+		}
 	},
 }
 
@@ -251,6 +266,7 @@ func AddNewCmdFlags(cmd *cobra.Command) {
 	cmd.Flags().VarP(&options.NewOpts.Name, "name", "n", "name of the project")
 	cmd.Flags().VarP(&options.NewOpts.License, "license", "l", "license to use for the project")
 	cmd.Flags().VarP(&options.NewOpts.Style, "style", "S", "which style to use")
+	cmd.Flags().BoolVarP(&options.NewOpts.NoGit, "no-git", "G", options.NewOpts.NoGit, "whether to not initialize git")
 }
 
 func WriteFiles(tmpRoot, projectRoot string, paths []string, licenseText string, tmpl, licenseTmpl map[string]string) error {

--- a/cmd/options/new.go
+++ b/cmd/options/new.go
@@ -19,6 +19,7 @@ var NewOpts = NewOptions{
 	Name:      *types.NewValueGuard("", cmdOpt, types.STRING),
 	License:   *types.NewValueGuard("", cmdOpt, types.STRING),
 	Style:     *types.NewValueGuard("", cmdOpt, types.STRING),
+	NoGit:     false,
 }
 
 type NewOptions struct {
@@ -40,6 +41,9 @@ type NewOptions struct {
 
 	// The style to use
 	Style types.ValueGuard[string]
+
+	// Whether to skip initializing git
+	NoGit bool
 }
 
 func cmdOpt(v string) (string, error) {


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the our Code of Conduct: https://github.com/{{REPOSITORY}}/blob/main/CODE_OF_CONDUCT.md
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Breaking Change
- [ ] Documentation Update

## Description

Runs `git init` in the project dir

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?

_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## Checklist

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
