### PR TITLE
fix: Manpage generation cmd not piping to stdout

### DIFF
--- a/cmd/global/version.go
+++ b/cmd/global/version.go
@@ -1,4 +1,4 @@
 package global
 
 // The current app version
-const Version = "0.2.5"
+const Version = "0.2.6"

--- a/cmd/man.go
+++ b/cmd/man.go
@@ -1,38 +1,31 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
-	"path/filepath"
 
-	"github.com/caffeine-addictt/waku/cmd/utils"
+	mango "github.com/muesli/mango-cobra"
+	"github.com/muesli/roff"
 	"github.com/spf13/cobra"
-	"github.com/spf13/cobra/doc"
 )
 
 var ManCmd = &cobra.Command{
-	Use:   "man",
-	Short: "generate man pages",
-	Long: utils.MultilineString(
-		"Generate man pages for the command.",
-		"By default, man pages are generated in /usr/share/man/man1.",
-	),
-	Hidden: true,
-	Args:   cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		dirPathDirty := "/usr/share/man/man1/"
-		if len(args) == 1 {
-			dirPathDirty = args[0]
+	Use:                   "man",
+	Short:                 "generate Waku's manpages",
+	Long:                  "Generate Waku's manpages.",
+	SilenceUsage:          true,
+	DisableFlagsInUseLine: true,
+	Hidden:                true,
+	Args:                  cobra.NoArgs,
+	ValidArgsFunction:     cobra.NoFileCompletions,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		manPage, err := mango.NewManPage(1, RootCmd)
+		if err != nil {
+			return err
 		}
 
-		dirPath := filepath.Clean(dirPathDirty)
-		if err := doc.GenManTree(RootCmd, &doc.GenManHeader{
-			Title:   "Waku Command Reference",
-			Source:  "Waku (waku!) 枠組み",
-			Section: "1",
-		}, dirPath); err != nil {
-			cmd.PrintErrf("could not create man pages: %v\n", err)
-			os.Exit(1)
-		}
+		_, err = fmt.Fprint(os.Stdout, manPage.Build(roff.NewDocument()))
+		return err
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,8 +14,9 @@ var RootCmd = &cobra.Command{
 	Use:   "waku",
 	Short: "let's make starting new projects feel like a breeze again",
 	Long: utils.MultilineString(
-		"Waku helps you kickstart new projects from templates.",
+		"Waku (waku!) 枠組み",
 		"",
+		"Waku helps you kickstart new projects from templates.",
 		"Let's make starting new projects feel like a breeze again.",
 	),
 }

--- a/docs/install.md
+++ b/docs/install.md
@@ -136,10 +136,10 @@ We sign our checksums with [Cosign](https://github.com/sigstore/cosign)
 
 ```sh
 cosign verify-blob \
-  --certificate-identity 'https://github.com/caffeine-addictt/waku/.github/workflows/release.yml@refs/tags/v0.2.5' \
+  --certificate-identity 'https://github.com/caffeine-addictt/waku/.github/workflows/release.yml@refs/tags/v0.2.6' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-  --cert 'https://github.com/caffeine-addictt/waku/releases/download/v0.2.5/checksums.txt.pem' \
-  --signature 'https://github.com/caffeine-addictt/waku/releases/download/v0.2.5/checksums.txt.sig' \
+  --cert 'https://github.com/caffeine-addictt/waku/releases/download/v0.2.6/checksums.txt.pem' \
+  --signature 'https://github.com/caffeine-addictt/waku/releases/download/v0.2.6/checksums.txt.sig' \
   ./checksums.txt
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.23.0
 require (
 	github.com/charmbracelet/huh v0.6.0
 	github.com/goccy/go-json v0.10.3
+	github.com/muesli/mango-cobra v1.2.0
+	github.com/muesli/roff v0.1.0
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
 )
@@ -19,7 +21,6 @@ require (
 	github.com/charmbracelet/x/ansi v0.2.3 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240829200707-9a7bd603a0d7 // indirect
 	github.com/charmbracelet/x/term v0.2.0 // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
@@ -31,10 +32,11 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/muesli/mango v0.2.0 // indirect
+	github.com/muesli/mango-pflag v0.1.0 // indirect
 	github.com/muesli/termenv v0.15.3-0.20240618155329-98d742f6907a // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,7 +20,6 @@ github.com/charmbracelet/x/exp/strings v0.0.0-20240829200707-9a7bd603a0d7 h1:RR1
 github.com/charmbracelet/x/exp/strings v0.0.0-20240829200707-9a7bd603a0d7/go.mod h1:pBhA0ybfXv6hDjQUZ7hk1lVxBiUbupdw5R31yPUViVQ=
 github.com/charmbracelet/x/term v0.2.0 h1:cNB9Ot9q8I711MyZ7myUR5HFWL/lc3OpU8jZ4hwm0x0=
 github.com/charmbracelet/x/term v0.2.0/go.mod h1:GVxgxAbjUrmpvIINHIQnJJKpMlHiZ4cktEQCN6GWyF0=
-github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -46,6 +45,14 @@ github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6/go.mod h1:CJlz5H+gyd6CUWT45Oy4q24RdLyn7Md9Vj2/ldJBSIo=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
+github.com/muesli/mango v0.2.0 h1:iNNc0c5VLQ6fsMgAqGQofByNUBH2Q2nEbD6TaI+5yyQ=
+github.com/muesli/mango v0.2.0/go.mod h1:5XFpbC8jY5UUv89YQciiXNlbi+iJgt29VDC5xbzrLL4=
+github.com/muesli/mango-cobra v1.2.0 h1:DQvjzAM0PMZr85Iv9LIMaYISpTOliMEg+uMFtNbYvWg=
+github.com/muesli/mango-cobra v1.2.0/go.mod h1:vMJL54QytZAJhCT13LPVDfkvCUJ5/4jNUKF/8NC2UjA=
+github.com/muesli/mango-pflag v0.1.0 h1:UADqbYgpUyRoBja3g6LUL+3LErjpsOwaC9ywvBWe7Sg=
+github.com/muesli/mango-pflag v0.1.0/go.mod h1:YEQomTxaCUp8PrbhFh10UfbhbQrM/xJ4i2PB8VTLLW0=
+github.com/muesli/roff v0.1.0 h1:YD0lalCotmYuF5HhZliKWlIx7IEhiXeSfq7hNjFqGF8=
+github.com/muesli/roff v0.1.0/go.mod h1:pjAHQM9hdUUwm/krAfrLGgJkXJ+YuhtsfZ42kieB2Ig=
 github.com/muesli/termenv v0.15.3-0.20240618155329-98d742f6907a h1:2MaM6YC3mGu54x+RKAA6JiFFHlHDY1UbkxqppT7wYOg=
 github.com/muesli/termenv v0.15.3-0.20240618155329-98d742f6907a/go.mod h1:hxSnBBYLK21Vtq/PHd0S2FYCxBXzBua8ov5s1RobyRQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -53,7 +60,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
-github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=


### PR DESCRIPTION
<!--
  Ensure that the Pull Request title and commits follows our
  [Commit Message Guidelines](https://github.com/caffeine-addictt/waku/blob/main/CONTRIBUTING.md#commit-message-guidelines).

  Fill in the following fields with the appropriate information.
-->

## Description

This fixes failing manpage installs

## Checklist

- [ ] I have read and understood the [Contributing Guide](https://github.com/caffeine-addictt/waku/blob/main/CONTRIBUTING.md).
- [x] I have tested the code and it is working as expected.
- [x] I have incremented version number in `cmd/global/version.go` according to [SemVer](https://semver.org).
