### PR TITLE
fix: Remove extra logging on error

### DIFF
--- a/cmd/global/version.go
+++ b/cmd/global/version.go
@@ -1,4 +1,4 @@
 package global
 
 // The current app version
-const Version = "0.3.2"
+const Version = "0.3.3"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"log"
-
 	"github.com/caffeine-addictt/waku/cmd/commands"
 	"github.com/caffeine-addictt/waku/cmd/options"
 	"github.com/caffeine-addictt/waku/cmd/utils"
@@ -32,7 +30,5 @@ func init() {
 
 // The main entry point for the command line tool
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		log.Fatal(err)
-	}
+	_ = RootCmd.Execute()
 }

--- a/www/docs/configuration/introduction.md
+++ b/www/docs/configuration/introduction.md
@@ -20,10 +20,10 @@ for better editor support.
 https://waku.ngjx.org/static/schema.json
 ```
 
-Or you can pin a specific version like `v0.3.2`:
+Or you can pin a specific version like `v0.3.3`:
 
 ```text
-https://raw.githubusercontent.com/caffeine-addictt/waku/v0.3.2/www/docs/static/schema.json
+https://raw.githubusercontent.com/caffeine-addictt/waku/v0.3.3/www/docs/static/schema.json
 ```
 
 Simply add the `$schema` property to your `template.json` file:

--- a/www/docs/install.md
+++ b/www/docs/install.md
@@ -108,17 +108,17 @@ All artifacts are checksummed, and the checksum file is signed with [cosign][].
 and `checksums.txt.sig` files from the [releases][] page.
 
     ```sh
-    curl -O 'https://github.com/caffeine-addictt/waku/releases/download/v0.3.2/checksums.txt'
+    curl -O 'https://github.com/caffeine-addictt/waku/releases/download/v0.3.3/checksums.txt'
     ```
 
 1. Verify checksums signature:
 
     ```bash
     cosign verify-blob \
-      --certificate-identity 'https://github.com/caffeine-addictt/waku/.github/workflows/release.yml@refs/tags/v0.3.2' \
+      --certificate-identity 'https://github.com/caffeine-addictt/waku/.github/workflows/release.yml@refs/tags/v0.3.3' \
       --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-      --cert 'https://github.com/caffeine-addictt/waku/releases/download/v0.3.2/checksums.txt.pem' \
-      --signature 'https://github.com/caffeine-addictt/waku/releases/download/v0.3.2/checksums.txt.sig' \
+      --cert 'https://github.com/caffeine-addictt/waku/releases/download/v0.3.3/checksums.txt.pem' \
+      --signature 'https://github.com/caffeine-addictt/waku/releases/download/v0.3.3/checksums.txt.sig' \
       ./checksums.txt
     ```
 
@@ -136,7 +136,7 @@ Verify the signature:
 
 ```sh
 cosign verify \
-  --certificate-identity 'https://github.com/caffeine-addictt/waku/.github/workflows/release.yml@refs/tags/v0.3.2' \
+  --certificate-identity 'https://github.com/caffeine-addictt/waku/.github/workflows/release.yml@refs/tags/v0.3.3' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   caffeinec/waku
 ```


### PR DESCRIPTION
The log.Fatal() can be removed because for .Execute() to reuturn an error means that that error is recoverable and the default CLI error msg has been thrown, so this fatal log is redundant.

<!--
  Ensure that the Pull Request title and commits follows our
  [Commit Message Guidelines](https://github.com/caffeine-addictt/waku/blob/main/CONTRIBUTING.md#commit-message-guidelines).

  Fill in the following fields with the appropriate information.
-->

## Description

The log.Fatal() can be removed because for .Execute() to reuturn an
error means that that error is recoverable and the default CLI error msg
has been thrown, so this fatal log is redundant.

## Checklist

- [ ] I have read and understood the [Contributing Guide](https://github.com/caffeine-addictt/waku/blob/main/CONTRIBUTING.md).
- [x] I have tested the code and it is working as expected.
- [x] I have incremented version number in `cmd/global/version.go` according to [SemVer](https://semver.org).
