### PR TITLE
feat: Warns should go to stderr

### DIFF
--- a/internal/log/warning.go
+++ b/internal/log/warning.go
@@ -1,23 +1,26 @@
 package log
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+)
 
 func Warnf(format string, a ...any) {
 	if logLevel <= WARNING {
-		fmt.Printf(warnPrefix+format, a...)
+		fmt.Fprintf(os.Stderr, warnPrefix+format, a...)
 	}
 }
 
 func Warnln(a ...any) {
 	if logLevel <= WARNING {
-		fmt.Print(warnPrefix)
-		fmt.Println(a...)
+		fmt.Fprint(os.Stderr, warnPrefix)
+		fmt.Fprintln(os.Stderr, a...)
 	}
 }
 
 func Warn(v ...any) {
 	if logLevel <= WARNING {
-		fmt.Print(warnPrefix)
-		fmt.Print(v...)
+		fmt.Fprint(os.Stderr, warnPrefix)
+		fmt.Fprint(os.Stderr, v...)
 	}
 }


### PR DESCRIPTION
<!--
  Ensure that the Pull Request title and commits follows our
  [Commit Message Guidelines](https://github.com/caffeine-addictt/waku/blob/main/CONTRIBUTING.md#commit-message-guidelines).

  Fill in the following fields with the appropriate information.
-->

## Description

- Make warns go to stderr not stdout

## Checklist

- [ ] I have read and understood the [Contributing Guide](https://github.com/caffeine-addictt/waku/blob/main/CONTRIBUTING.md).
- [x] I have tested the code and it is working as expected.
- [ ] I have incremented version number in `cmd/global/version.go` according to [SemVer](https://semver.org).
