### PR TITLE
ci: Fix snapcraft not being found by apt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,7 @@ jobs:
 
       - name: setup-snapcraft
         run: |
-          sudo apt-get update
-          sudo apt-get -yq --no-install-suggests --no-install-recommends install snapcraft
+          sudo snap install snapcraft --classic
 
       - name: Set up Chocolately
         run: |


### PR DESCRIPTION
<!--
  Ensure that the Pull Request title and commits follows our
  [Commit Message Guidelines](https://github.com/caffeine-addictt/waku/blob/main/CONTRIBUTING.md#commit-message-guidelines).

  Fill in the following fields with the appropriate information.
-->

## Description

Looks like release CI is failing due to `apt-get install snapcraft` throwing.

## Checklist

- [x] I have read and understood the [Contributing Guide](https://github.com/caffeine-addictt/waku/blob/main/CONTRIBUTING.md).
- [ ] I have tested the code and it is working as expected.
- [ ] I have incremented the version number with `make bump version=vX.X.X` according to [SemVer](https://semver.org).
