### PR TITLE
fix: Print created project dir afterward

### DIFF
--- a/cmd/commands/new.go
+++ b/cmd/commands/new.go
@@ -267,17 +267,22 @@ var NewCmd = &cobra.Command{
 
 		if options.NewOpts.NoGit {
 			log.Infoln("skipping git initialization")
-			return nil
+		} else {
+			err = ui.RunWithSpinner("initializing git...", func() error {
+				return git.Init(projectRootDir)
+			})
+			if err != nil {
+				fmt.Printf("failed to initialize git: %s\n", err)
+				return errors.NewWakuErrorf("failed to initialize git: %s\n", err)
+			}
 		}
 
-		err = ui.RunWithSpinner("initializing git...", func() error {
-			return git.Init(projectRootDir)
-		})
+		dirPath, err := filepath.Abs(projectRootDir)
 		if err != nil {
-			fmt.Printf("failed to initialize git: %s\n", err)
-			return errors.NewWakuErrorf("failed to initialize git: %s\n", err)
+			return errors.ToWakuError(err)
 		}
 
+		log.Printf("Project created at: %s\n", dirPath)
 		return nil
 	},
 }


### PR DESCRIPTION
<!--
  Ensure that the Pull Request title and commits follows our
  [Commit Message Guidelines](https://github.com/caffeine-addictt/waku/blob/main/CONTRIBUTING.md#commit-message-guidelines).

  Fill in the following fields with the appropriate information.
-->

## Description

Forgot to include this final print

### Additional

<!--Like if you need help writing tests etc.-->

## Related

- Closes #
- Related Issue #

## Checklist

- [ ] I have read and understood the [Contributing Guide](https://github.com/caffeine-addictt/waku/blob/main/CONTRIBUTING.md).
- [ ] I have tested the code and it is working as expected.
- [ ] I have incremented the version number with `make bump version=vX.X.X` according to [SemVer](https://semver.org).
