### PR TITLE
feat: Implement --no-license/-L flag

### DIFF
--- a/cmd/options/new.go
+++ b/cmd/options/new.go
@@ -25,6 +25,7 @@ var NewOpts = NewOptions{
 	License:   *types.NewValueGuard("", cmdOpt, types.STRING),
 	Style:     *types.NewValueGuard("", cmdOpt, types.STRING),
 	NoGit:     false,
+	NoLicense: false,
 }
 
 type NewOptions struct {
@@ -53,6 +54,9 @@ type NewOptions struct {
 
 	// Whether to skip initializing git
 	NoGit bool
+
+	// Whether to skip initializing license
+	NoLicense bool
 }
 
 func cmdOpt(v string) (string, error) {


### PR DESCRIPTION
<!--
  Ensure that the Pull Request title and commits follows our
  [Commit Message Guidelines](https://github.com/caffeine-addictt/waku/blob/main/CONTRIBUTING.md#commit-message-guidelines).

  Fill in the following fields with the appropriate information.
-->

## Description

Adds the `--no-license` and `-L` flags that are mutually exclusive with the `--license` and `-l` flags.

## Related

- Closes #168

## Checklist

- [ ] I have read and understood the [Contributing Guide](https://github.com/caffeine-addictt/waku/blob/main/CONTRIBUTING.md).
- [x] I have tested the code and it is working as expected.
- [ ] I have incremented the version number with `make bump version=vX.X.X` according to [SemVer](https://semver.org).
