### PR TITLE
feat: Migrate gopkg.in/yaml -> goccy/go-yaml 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,17 +6,11 @@ require (
 	github.com/charmbracelet/huh v0.6.0
 	github.com/go-git/go-git/v5 v5.14.0
 	github.com/goccy/go-json v0.10.5
+	github.com/goccy/go-yaml v1.17.1
 	github.com/muesli/mango-cobra v1.2.0
 	github.com/muesli/roff v0.1.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
-	gopkg.in/yaml.v3 v3.0.1
-)
-
-require (
-	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
-	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 )
 
 require (
@@ -28,9 +22,11 @@ require (
 	github.com/catppuccin/go v0.2.0 // indirect
 	github.com/charmbracelet/bubbles v0.20.0 // indirect
 	github.com/charmbracelet/bubbletea v1.2.5-0.20241205214244-9306010a31ee // indirect
+	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/huh/spinner v0.0.0-20250109160224-6c6b31916f8e
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect
+	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20250117142827-dd310ffa7553 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/cloudflare/circl v1.6.0 // indirect
@@ -62,10 +58,12 @@ require (
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/crypto v0.35.0 // indirect
 	golang.org/x/net v0.36.0 // indirect
 	golang.org/x/sync v0.11.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/go-git/go-git/v5 v5.14.0 h1:/MD3lCrGjCen5WfEAzKg00MJJffKhC8gzS80ycmCi
 github.com/go-git/go-git/v5 v5.14.0/go.mod h1:Z5Xhoia5PcWA3NF8vRLURn9E5FRhSl7dGj9ItW3Wk5k=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=
+github.com/goccy/go-yaml v1.17.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,27 @@
+// For joining the Marshal and Unmarshal
+// methods for all supported config types.
+package config
+
+import (
+	"github.com/goccy/go-json"
+	"github.com/goccy/go-yaml"
+)
+
+// ConfigType is a generic interface for
+// marshalling and unmarshalling config types
+type ConfigType interface {
+	Marshal(interface{}) ([]byte, error)
+	Unmarshal([]byte, interface{}) error
+}
+
+// JsonConfig implements the ConfigType interface
+type JsonConfig struct{}
+
+func (JsonConfig) Unmarshal(data []byte, v interface{}) error { return json.Unmarshal(data, v) }
+func (JsonConfig) Marshal(v interface{}) ([]byte, error)      { return json.Marshal(v) }
+
+// YamlConfig implements the ConfigType interface
+type YamlConfig struct{}
+
+func (YamlConfig) Unmarshal(data []byte, v interface{}) error { return yaml.Unmarshal(data, v) }
+func (YamlConfig) Marshal(v interface{}) ([]byte, error)      { return yaml.Marshal(v) }

--- a/internal/template/parse_config.go
+++ b/internal/template/parse_config.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/caffeine-addictt/waku/pkg/config"
 	"github.com/caffeine-addictt/waku/pkg/log"
-	"gopkg.in/yaml.v3"
+	"github.com/goccy/go-yaml"
 )
 
 func ParseConfig(filePath string) (string, *config.TemplateJson, error) {

--- a/internal/types/clean_string.go
+++ b/internal/types/clean_string.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/caffeine-addictt/waku/internal/config"
 	"github.com/caffeine-addictt/waku/internal/utils"
-	"github.com/goccy/go-json"
-	"gopkg.in/yaml.v3"
 )
 
 // String that has a Clean method that also is invoked on UnmarshalJSON
@@ -21,9 +20,9 @@ func (s *CleanString) String() string {
 	return string(*s)
 }
 
-func (s *CleanString) UnmarshalYAML(node *yaml.Node) error {
+func (s *CleanString) unmarshal(cfg config.ConfigType, data []byte) error {
 	var tmp string
-	if err := node.Decode(&tmp); err != nil {
+	if err := cfg.Unmarshal(data, &tmp); err != nil {
 		return err
 	}
 
@@ -36,17 +35,10 @@ func (s *CleanString) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
+func (s *CleanString) UnmarshalYAML(data []byte) error {
+	return s.unmarshal(config.YamlConfig{}, data)
+}
+
 func (s *CleanString) UnmarshalJSON(data []byte) error {
-	var tmp string
-	if err := json.Unmarshal(data, &tmp); err != nil {
-		return err
-	}
-
-	tmp = utils.CleanString(strings.TrimSpace(tmp))
-	if tmp == "" {
-		return fmt.Errorf("invalid string: %s", string(tmp))
-	}
-
-	*s = CleanString(tmp)
-	return nil
+	return s.unmarshal(config.JsonConfig{}, data)
 }

--- a/internal/types/clean_string_test.go
+++ b/internal/types/clean_string_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/caffeine-addictt/waku/internal/types"
+	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
 )
 
 func TestCleanStringUnmarshalJSON(t *testing.T) {

--- a/internal/types/color.go
+++ b/internal/types/color.go
@@ -4,18 +4,17 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/goccy/go-json"
-	"gopkg.in/yaml.v3"
+	"github.com/caffeine-addictt/waku/internal/config"
 )
 
 type HexColor string
 
 var hexColorRegex = regexp.MustCompile(`^#(?:[0-9a-fA-F]{3}){1,2}$`)
 
-func (c *HexColor) UnmarshalJSON(data []byte) error {
+func (c *HexColor) unmarshal(cfg config.ConfigType, data []byte) error {
 	var color string
 
-	if err := json.Unmarshal(data, &color); err != nil {
+	if err := cfg.Unmarshal(data, &color); err != nil {
 		return err
 	}
 
@@ -27,16 +26,10 @@ func (c *HexColor) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (c *HexColor) UnmarshalYAML(node *yaml.Node) error {
-	var color string
-	if err := node.Decode(&color); err != nil {
-		return err
-	}
+func (c *HexColor) UnmarshalYAML(data []byte) error {
+	return c.unmarshal(config.YamlConfig{}, data)
+}
 
-	if !hexColorRegex.MatchString(string(color)) {
-		return fmt.Errorf("invalid hex color: %s", color)
-	}
-
-	*c = HexColor(color)
-	return nil
+func (c *HexColor) UnmarshalJSON(data []byte) error {
+	return c.unmarshal(config.JsonConfig{}, data)
 }

--- a/internal/types/color_test.go
+++ b/internal/types/color_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/caffeine-addictt/waku/internal/types"
+	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
 )
 
 var hexColorTT = []struct {

--- a/internal/types/regex.go
+++ b/internal/types/regex.go
@@ -3,17 +3,16 @@ package types
 import (
 	"regexp"
 
-	"github.com/goccy/go-json"
-	"gopkg.in/yaml.v3"
+	"github.com/caffeine-addictt/waku/internal/config"
 )
 
 type RegexString struct {
 	*regexp.Regexp
 }
 
-func (r *RegexString) UnmarshalJSON(data []byte) error {
+func (r *RegexString) unmarshal(cfg config.ConfigType, data []byte) error {
 	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
+	if err := cfg.Unmarshal(data, &s); err != nil {
 		return err
 	}
 
@@ -26,17 +25,10 @@ func (r *RegexString) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (r *RegexString) UnmarshalYAML(node *yaml.Node) error {
-	var s string
-	if err := node.Decode(&s); err != nil {
-		return err
-	}
+func (r *RegexString) UnmarshalYAML(data []byte) error {
+	return r.unmarshal(config.YamlConfig{}, data)
+}
 
-	re, err := regexp.Compile(s)
-	if err != nil {
-		return err
-	}
-
-	r.Regexp = re
-	return nil
+func (r *RegexString) UnmarshalJSON(data []byte) error {
+	return r.unmarshal(config.JsonConfig{}, data)
 }

--- a/internal/types/regex_test.go
+++ b/internal/types/regex_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/caffeine-addictt/waku/internal/types"
 	"github.com/goccy/go-json"
+	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
 )
 
 var regexStringTT = []struct {

--- a/internal/types/set.go
+++ b/internal/types/set.go
@@ -1,8 +1,7 @@
 package types
 
 import (
-	"github.com/goccy/go-json"
-	"gopkg.in/yaml.v3"
+	"github.com/caffeine-addictt/waku/internal/config"
 )
 
 // A set implementation using map under the hood.
@@ -99,32 +98,18 @@ func (s *Set[T]) Exclude(s2 Set[T]) Set[T] {
 	return s3
 }
 
-// UnmarshalJSON unmarshals a JSON array into a set
-func (s *Set[T]) UnmarshalJSON(data []byte) error {
+func (s *Set[T]) marshal(c config.ConfigType) ([]byte, error) { return c.Marshal(s.ToSlice()) }
+func (s *Set[T]) unmarshal(c config.ConfigType, data []byte) error {
 	var items []T
-	if err := json.Unmarshal(data, &items); err != nil {
+	if err := c.Unmarshal(data, &items); err != nil {
 		return err
 	}
 	*s = NewSet(items...)
 	return nil
 }
 
-// MarshalJSON marshals a set into a JSON array
-func (s Set[T]) MarshalJSON() ([]byte, error) {
-	return json.Marshal(s.ToSlice())
-}
+func (s *Set[T]) UnmarshalJSON(data []byte) error { return s.unmarshal(config.JsonConfig{}, data) }
+func (s Set[T]) MarshalJSON() ([]byte, error)     { return s.marshal(config.JsonConfig{}) }
 
-// UnmarshalYAML unmarshals a YAML string into a set
-func (s *Set[T]) UnmarshalYAML(node *yaml.Node) error {
-	var items []T
-	if err := node.Decode(&items); err != nil {
-		return err
-	}
-	*s = NewSet(items...)
-	return nil
-}
-
-// MarshalYAML marshals a set into a YAML string
-func (s Set[T]) MarshalYAML() (interface{}, error) {
-	return s.ToSlice(), nil
-}
+func (s *Set[T]) UnmarshalYAML(data []byte) error { return s.unmarshal(config.YamlConfig{}, data) }
+func (s Set[T]) MarshalYAML() ([]byte, error)     { return s.marshal(config.YamlConfig{}) }

--- a/internal/types/set_test.go
+++ b/internal/types/set_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/caffeine-addictt/waku/internal/types"
 	"github.com/goccy/go-json"
+	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
 )
 
 func TestSetNewSet(t *testing.T) {

--- a/internal/types/value_guard_test.go
+++ b/internal/types/value_guard_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/caffeine-addictt/waku/internal/types"
 	"github.com/goccy/go-json"
+	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
 )
 
 func TestNoParsing(t *testing.T) {


### PR DESCRIPTION
This is in response to `gopkg.in/yaml.vX` being archived and marked as unmaintained [1]. Since we are already using goccy's `go-json`, it makes sense to migrate over to goccy's `go-yaml` as well.

[1]: https://github.com/go-yaml/yaml/commit/944c86a7d29391925ed6ac33bee98a0516f1287a