### PR TITLE
fix: .License & .Spdx do not exist if -L is set

### DIFF
--- a/cmd/commands/new.go
+++ b/cmd/commands/new.go
@@ -216,6 +216,9 @@ var NewCmd = &cobra.Command{
 			if !options.NewOpts.NoLicense {
 				finalTemplateData["License"] = license.Name
 				finalTemplateData["Spdx"] = license.Spdx
+			} else {
+				finalTemplateData["License"] = ""
+				finalTemplateData["Spdx"] = ""
 			}
 			log.Debugf("final template data: %v\n", finalTemplateData)
 


### PR DESCRIPTION
.License and .Spdx are unset if `-L/--no-license` is set